### PR TITLE
Simplify CI workflows to avoid running duplicate checks

### DIFF
--- a/.github/workflows/build-container-images.yml
+++ b/.github/workflows/build-container-images.yml
@@ -5,27 +5,15 @@ env:
   CONTAINER_IMAGE_REGISTRY: ghcr.io
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    paths:
-      - ".github/workflows/build-container-images.yml"
-      - ".github/workflows/lint.yml"
-      - "docker/**"
-  pull_request:
-    paths:
-      - ".github/workflows/build-container-images.yml"
-      - ".github/workflows/lint.yml"
-      - "docker/**"
+  push: null
+  pull_request: null
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch: null
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yml
   build-container-images:
     env:
       CONTAINER_IMAGE_ID: "${{ github.repository }}-${{ matrix.container-image-context-directory }}"
-    needs:
-      - lint
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/validate-shell-scripts.yml
+++ b/.github/workflows/validate-shell-scripts.yml
@@ -5,13 +5,8 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 on:  # yamllint disable-line rule:truthy
-  push:
-    paths:
-      - "scripts/**"
-
-  pull_request:
-    paths:
-      - "scripts/**"
+  push: null
+  pull_request: null
 
   # Validate scrtips every Sunday at 00:00
   schedule:
@@ -21,14 +16,10 @@ on:  # yamllint disable-line rule:truthy
   workflow_dispatch: null
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yml
   validate-shell-scripts:
     strategy:
       matrix:
         os: [ubuntu-22.04, macos-latest]
-    needs:
-      - lint
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validate-terraform.yml
+++ b/.github/workflows/validate-terraform.yml
@@ -3,18 +3,13 @@ name: Validate Terraform
 
 # Controls when the workflow will run
 on: # yamllint disable-line rule:truthy
-  # Triggers the workflow on pull request events but only for the main branch
-  pull_request:
-    branches: [main]
   push: null
+  pull_request: null
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch: null
 
 jobs:
-  lint:
-    uses: ./.github/workflows/lint.yml
-
   ci:
     runs-on: ubuntu-22.04
 
@@ -25,13 +20,11 @@ jobs:
         uses: hashicorp/setup-terraform@v2
 
       - name: Terraform Init
-        id: init
         working-directory: terraform
         # Do not initialize backend
         run: terraform init -backend=false -input=false
 
       - name: Terraform validate
-        id: lint
         working-directory: terraform
         run: terraform validate
 ...


### PR DESCRIPTION
In this PR, we simplify the GitHub Actions workflows to avoid running the `lint` job multiple times.