### PR TITLE
Prevent maintainers from using personal forks for PRs

### DIFF
--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -23,7 +23,7 @@ jobs:
             const username = context.payload.pull_request.user.login;
             const permissions = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
-              repo: context.repo.name,
+              repo: context.repo.repo,
               username: username
             });
             const hasPushAccess = permissions.data.permission == 'admin'

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -21,6 +21,7 @@ jobs:
         with:
           script: |
             const username = context.payload.pull_request.user.login;
+            const github = context.github; // Explicitly declare the context.github object
             const permissions = await github.repos.get({
               owner: context.repo.owner,
               repo: context.repo.name,

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -1,6 +1,8 @@
 ---
 name: Check PR origin for users with push access to the repository
-on: [pull_request]
+on:
+  merge_group: null
+  pull_request: null
 jobs:
   check-origin:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -10,7 +10,7 @@ jobs:
         id: check-origin
         with:
           script: |
-            console.log(`Context payload: ${context.payload}`)
+            console.log(context.payload)
             const pr = context.payload.pull_request;
             const repoName = pr.base.repo.full_name;
             console.log(`PR base repository full name: ${repoName}`);

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -7,6 +7,7 @@ jobs:
     steps:
       - name: Get PR information
         uses: actions/github-script@v6
+        id: check_origin
         with:
           script: |
             const pr = context.payload.pull_request;

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -21,8 +21,7 @@ jobs:
         with:
           script: |
             const username = context.payload.pull_request.user.login;
-            const github = context.github; // Explicitly declare the context.github object
-            const permissions = await github.repos.get({
+            const permissions = await github.rest.repos.get({
               owner: context.repo.owner,
               repo: context.repo.name,
               username: username

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -10,6 +10,7 @@ jobs:
         id: check-origin
         with:
           script: |
+            console.debug(context.payload);
             const repoName = context.payload.repository.full_name;
             console.log(`Repository full name: ${repoName}`);
 

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -13,7 +13,7 @@ jobs:
             const pr = context.payload.pull_request;
             const baseRef = pr.base.ref;
             const repoName = pr.base.repo.full_name;
-            const isFork = (repoName !== context.repo.owner + '/' + context.repo.name);
+            const isFork = (repoName !== context.repo.owner + '/' + context.repo.repo);
             core.setOutput('isFork', isFork);
 
       - name: Get user permissions

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -21,12 +21,13 @@ jobs:
         with:
           script: |
             const username = context.payload.pull_request.user.login;
-            const permissions = await github.rest.repos.get({
+            const permissions = await github.rest.repos.getCollaboratorPermissionLevel({
               owner: context.repo.owner,
               repo: context.repo.name,
               username: username
             });
-            const hasPushAccess = permissions.data.permissions.push;
+            const hasPushAccess = permissions.data.permission == 'admin'
+              || permissions.data.permission == 'write';
             core.setOutput('hasPushAccess', hasPushAccess);
 
       - name: Fail if PR is from a fork and user has push access

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -12,7 +12,7 @@ jobs:
           script: |
             console.log(context.payload);
             const repoName = context.payload.repository.full_name;
-            console.log(`PR base repository full name: ${prRepoName}`);
+            console.log(`Repository full name: ${repoName}`);
 
             const pr = context.payload.pull_request;
             const prRepoName = pr.base.repo.full_name;

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -1,6 +1,8 @@
 ---
 name: Check PR origin for users with push access to the repository
-on: [pull_request]
+on:
+  push: null
+  pull_request: null
 jobs:
   check-origin:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -1,0 +1,29 @@
+---
+name: Check PR origin for users with push access to the repository
+on: [pull_request]
+jobs:
+  check-origin:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get PR information
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const baseRef = pr.base.ref;
+            const repoName = pr.base.repo.full_name;
+            const isFork = (repoName !== context.repo.owner + '/' + context.repo.name);
+            core.setOutput('isFork', isFork);
+
+            // Check if user has push access
+            const hasPushAccess = pr.user.permissions.push;
+            core.setOutput('hasPushAccess', hasPushAccess);
+
+      - name: Fail if PR is from a fork for users with push access
+        if: >
+          steps.check_origin.outputs.isFork
+          && steps.check_origin.outputs.hasPushAccess
+        run: |
+          echo "This pull request is from a forked repository. We only accept PRs from branches within the repository for users with push access."
+          exit 1
+...

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -10,7 +10,6 @@ jobs:
         id: check-origin
         with:
           script: |
-            console.debug(context.payload);
             const repoName = context.payload.repository.full_name;
             console.log(`Repository full name: ${repoName}`);
 
@@ -19,8 +18,8 @@ jobs:
             console.debug(pr.base)
             console.debug("PR Head:")
             console.debug(pr.head)
-            const prRepoName = pr.base.repo.full_name;
-            console.log(`PR base repository full name: ${prRepoName}`);
+            const prRepoName = pr.head.repo.full_name;
+            console.log(`PR head repository full name: ${prRepoName}`);
             const isFork = (prRepoName !== repoName);
             core.setOutput('isFork', isFork);
 

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -5,9 +5,9 @@ jobs:
   check-origin:
     runs-on: ubuntu-latest
     steps:
-      - name: Get PR information
+      - name: Check if the PR comes from a fork
         uses: actions/github-script@v6
-        id: check_origin
+        id: check-origin
         with:
           script: |
             const pr = context.payload.pull_request;
@@ -33,8 +33,8 @@ jobs:
 
       - name: Fail if PR is from a fork and user has push access
         if: >
-          steps.check_origin.outputs.isFork
-          && steps.get-permissions.outputs.hasPushAccess
+          steps.check-origin.outputs.isFork == 'true'
+          && steps.get-permissions.outputs.hasPushAccess == 'true'
         run: |
           echo "This pull request is from a forked repository. We only accept PRs from branches within the repository for users with push access."
           exit 1

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -10,7 +10,6 @@ jobs:
         id: check-origin
         with:
           script: |
-            console.log(context.payload);
             const repoName = context.payload.repository.full_name;
             console.log(`Repository full name: ${repoName}`);
 

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -10,9 +10,10 @@ jobs:
         id: check-origin
         with:
           script: |
+            console.log(`Context payload: ${context.payload}`)
             const pr = context.payload.pull_request;
-            const baseRef = pr.base.ref;
             const repoName = pr.base.repo.full_name;
+            console.log(`PR base repository full name: ${repoName}`);
             const isFork = (repoName !== context.repo.owner + '/' + context.repo.repo);
             core.setOutput('isFork', isFork);
 

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -15,14 +15,24 @@ jobs:
             const isFork = (repoName !== context.repo.owner + '/' + context.repo.name);
             core.setOutput('isFork', isFork);
 
-            // Check if user has push access
-            const hasPushAccess = pr.user.permissions.push;
+      - name: Get user permissions
+        uses: actions/github-script@v6
+        id: get-permissions
+        with:
+          script: |
+            const username = context.payload.pull_request.user.login;
+            const permissions = await github.repos.get({
+              owner: context.repo.owner,
+              repo: context.repo.name,
+              username: username
+            });
+            const hasPushAccess = permissions.data.permissions.push;
             core.setOutput('hasPushAccess', hasPushAccess);
 
-      - name: Fail if PR is from a fork for users with push access
+      - name: Fail if PR is from a fork and user has push access
         if: >
           steps.check_origin.outputs.isFork
-          && steps.check_origin.outputs.hasPushAccess
+          && steps.get-permissions.outputs.hasPushAccess
         run: |
           echo "This pull request is from a forked repository. We only accept PRs from branches within the repository for users with push access."
           exit 1

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -15,7 +15,10 @@ jobs:
             console.log(`Repository full name: ${repoName}`);
 
             const pr = context.payload.pull_request;
+            console.debug("PR Base:")
             console.debug(pr.base)
+            console.debug("PR Head:")
+            console.debug(pr.head)
             const prRepoName = pr.base.repo.full_name;
             console.log(`PR base repository full name: ${prRepoName}`);
             const isFork = (prRepoName !== repoName);

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -10,11 +10,14 @@ jobs:
         id: check-origin
         with:
           script: |
-            console.log(context.payload)
+            console.log(context.payload);
+            const repoName = context.payload.repository.full_name;
+            console.log(`PR base repository full name: ${prRepoName}`);
+
             const pr = context.payload.pull_request;
-            const repoName = pr.base.repo.full_name;
-            console.log(`PR base repository full name: ${repoName}`);
-            const isFork = (repoName !== context.repo.owner + '/' + context.repo.repo);
+            const prRepoName = pr.base.repo.full_name;
+            console.log(`PR base repository full name: ${prRepoName}`);
+            const isFork = (prRepoName !== repoName);
             core.setOutput('isFork', isFork);
 
       - name: Get user permissions

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -14,10 +14,6 @@ jobs:
             console.log(`Repository full name: ${repoName}`);
 
             const pr = context.payload.pull_request;
-            console.debug("PR Base:")
-            console.debug(pr.base)
-            console.debug("PR Head:")
-            console.debug(pr.head)
             const prRepoName = pr.head.repo.full_name;
             console.log(`PR head repository full name: ${prRepoName}`);
             const isFork = (prRepoName !== repoName);

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -1,8 +1,6 @@
 ---
 name: Check PR origin for users with push access to the repository
-on:
-  merge_group: null
-  pull_request: null
+on: [pull_request]
 jobs:
   check-origin:
     runs-on: ubuntu-latest

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -15,6 +15,7 @@ jobs:
             console.log(`Repository full name: ${repoName}`);
 
             const pr = context.payload.pull_request;
+            console.debug(pr.base)
             const prRepoName = pr.base.repo.full_name;
             console.log(`PR base repository full name: ${prRepoName}`);
             const isFork = (prRepoName !== repoName);

--- a/.github/workflows/check-pr-origin.yaml
+++ b/.github/workflows/check-pr-origin.yaml
@@ -1,8 +1,6 @@
 ---
 name: Check PR origin for users with push access to the repository
-on:
-  push: null
-  pull_request: null
+on: [pull_request]
 jobs:
   check-origin:
     runs-on: ubuntu-latest

--- a/config/lint/super-linter.env
+++ b/config/lint/super-linter.env
@@ -1,6 +1,6 @@
 DISABLE_ERRORS=false
 ERROR_ON_MISSING_EXEC_BIT=trues
-GITHUB_ACTIONS_COMMAND_ARGS="-ignore 'property \"check_origin\" is not defined in object type'"
+GITHUB_ACTIONS_COMMAND_ARGS=-ignore 'property \"check_origin\" is not defined in object type'
 LINTER_RULES_PATH=config/lint
 VALIDATE_ALL_CODEBASE=true
 VALIDATE_KUBERNETES_KUBECONFORM=false

--- a/config/lint/super-linter.env
+++ b/config/lint/super-linter.env
@@ -1,6 +1,5 @@
 DISABLE_ERRORS=false
 ERROR_ON_MISSING_EXEC_BIT=trues
-GITHUB_ACTIONS_COMMAND_ARGS=-ignore 'property \"check_origin\" is not defined in object type'
 LINTER_RULES_PATH=config/lint
 VALIDATE_ALL_CODEBASE=true
 VALIDATE_KUBERNETES_KUBECONFORM=false

--- a/config/lint/super-linter.env
+++ b/config/lint/super-linter.env
@@ -1,5 +1,6 @@
 DISABLE_ERRORS=false
 ERROR_ON_MISSING_EXEC_BIT=trues
+GITHUB_ACTIONS_COMMAND_ARGS="-ignore 'property \"check_origin\" is not defined in object type'"
 LINTER_RULES_PATH=config/lint
 VALIDATE_ALL_CODEBASE=true
 VALIDATE_KUBERNETES_KUBECONFORM=false

--- a/docs/development.md
+++ b/docs/development.md
@@ -2,6 +2,15 @@
 
 This document explains how to develop VIAI Edge.
 
+## Creating pull requests
+
+When creating pull requests, maintainers are required to work in a branch of
+this repository. If a maintainer creates a pull request against any branch of
+this repository from a fork, a
+[required workflow will return an error](../.github/workflows/check-pr-origin.yaml).
+
+Contributors that are not maintainers can work in their own forks.
+
 ## Requirements
 
 To setup a development environment you need:


### PR DESCRIPTION
In this PR, we implement a GitHub Actions workflow to prevent users with push access to the repository from opening PRs from forks.