### PR TITLE
Run Terraform validation locally

### DIFF
--- a/.github/workflows/validate-terraform.yml
+++ b/.github/workflows/validate-terraform.yml
@@ -11,20 +11,16 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   ci:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
-
     steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
       - uses: actions/checkout@v4
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v3
-
-      - name: Terraform Init
-        working-directory: terraform
-        # Do not initialize backend
-        run: terraform init -backend=false -input=false
-
-      - name: Terraform validate
-        working-directory: terraform
-        run: terraform validate
+      - name: Validate Terraform descriptors using the validation script
+        run: |
+          tests/validate-terraform.sh
 ...

--- a/docs/development.md
+++ b/docs/development.md
@@ -64,3 +64,29 @@ To run build container images locally, do the following:
 ```shell
 tests/build-container-images.sh
 ```
+
+## Cloud infrastructure validation
+
+This project provisions [Google Cloud](https://cloud.google.com) resources using
+[Terraform](https://www.terraform.io/).
+
+[A GitHub Actions workflow](../.github/workflows/validate-terraform.yml)
+runs basic validation checks on all Terraform descriptors as part of the build
+process. These validation checks currently include:
+
+- Terraform providers installation
+- Terraform modules installation
+- Running the [`terraform validate` command](https://developer.hashicorp.com/terraform/cli/commands/validate)
+
+### Validate cloud infrastructure descriptors validation checks from the command-line
+
+To run cloud infrastructure validation checks from the command-line, do the
+following:
+
+1. Open a POSIX-compliant shell.
+2. Change your working directory to the root directory of this repository.
+3. Run the cloud infrastructure validation process:
+
+```shell
+tests/validate-terraform.sh
+```

--- a/tests/validate-terraform.sh
+++ b/tests/validate-terraform.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -o errexit
+set -o nounset
+
+# shellcheck disable=SC1091,SC1094
+. ./scripts/common.sh
+
+echo "Running cloud infrastructure descriptors validation checks"
+
+# Run a dummy container because the function to run Terraform requires
+# it to fetch authentication data, even if we don't need it.
+docker run --name "${GCLOUD_AUTHENTICATION_CONTAINER_NAME}" "hello-world"
+
+# Do not initialize backend because we don't have a cloud environment
+run_containerized_terraform "$(pwd)" "$(pwd)" init -backend=false -input=false
+run_containerized_terraform "$(pwd)" "$(pwd)" validate
+
+docker rm "${GCLOUD_AUTHENTICATION_CONTAINER_NAME}"


### PR DESCRIPTION
This PR documents the (basic) Terraform descriptors validation checks that we run as part of our CI workflows, and provides a script to do that outside the CI environment.